### PR TITLE
Add switching between English and Indonesian

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,6 +26,9 @@
       <li class="nav-item">
         <a class="nav-link" href="https://portal.domcloud.id/id/login">Masuk</a>
       </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://domcloud.id/en/">English</a>
+      </li>
     </ul>
     {% else %}
     <ul class="navbar-nav ml-auto">
@@ -40,6 +43,9 @@
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://portal.domcloud.id/en/login">Sign in</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://domcloud.id/">Indonesian</a>
       </li>
     </ul>
     {% endif %}


### PR DESCRIPTION
Currently, the top page of Indonesian is displayed in search results such as Google from any region. We need a switch link to the English page.